### PR TITLE
Fix external function validation error message

### DIFF
--- a/addons/inkgd/runtime/story.gd
+++ b/addons/inkgd/runtime/story.gd
@@ -1195,7 +1195,7 @@ func validate_external_bindings():
     else:
         var message = "ERROR: Missing function binding for external%s: '%s' %s" % [
             "s" if missing_externals.size() > 1 else "",
-            Utils.join("', '", missing_externals),
+            Utils.join("', '", missing_externals._dictionary.keys()),
             ", and no fallback ink function found." if allow_external_function_fallbacks else " (ink fallbacks disabled)"
         ]
 

--- a/addons/inkgd/runtime/story.gd
+++ b/addons/inkgd/runtime/story.gd
@@ -1195,7 +1195,7 @@ func validate_external_bindings():
     else:
         var message = "ERROR: Missing function binding for external%s: '%s' %s" % [
             "s" if missing_externals.size() > 1 else "",
-            Utils.join("', '", missing_externals._dictionary.keys()),
+            Utils.join("', '", missing_externals.to_array()),
             ", and no fallback ink function found." if allow_external_function_fallbacks else " (ink fallbacks disabled)"
         ]
 


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description
Hey!

Great addon! I fixed a small issue I encountered in the function binding validation. You're using Utils.join which expects an Array but a StringSet is provided. Not sure if there is a cleaner way but I simply changed it so that it hands over the keys of the backing Dictionary instead.

On a related note, I also added the following lines to the "add_error" method of `story.gd` locally but since I'm not sure if you support Godot 3.1, I left it out of this PR:

```
    if is_warning:
        push_warning(message)
    else:
        push_error(message)		
```

That way, the messages really appear in the Godot error log. But this should probably be controlled by a settings flag as well.