### PR TITLE
Fix unbind_external_function

### DIFF
--- a/addons/inkgd/runtime/story.gd
+++ b/addons/inkgd/runtime/story.gd
@@ -1182,7 +1182,7 @@ func unbind_external_function(func_name):
         return
 
     self.assert(_externals.has(func_name), str("Function '", func_name, "' has not been bound."))
-    _externals.remove(func_name)
+    _externals.erase(func_name)
 
 func validate_external_bindings():
     var missing_externals = StringSet.new()


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

External function bindings are stored in a Dictionary which requires "erase" to delete an entry by key. Currently, "remove" is used which is used in Arrays instead.