### PR TITLE
Stop configuration instance from leaking

### DIFF
--- a/addons/inkgd/editor/ink_dock.gd
+++ b/addons/inkgd/editor/ink_dock.gd
@@ -10,16 +10,10 @@ tool
 extends Control
 
 # ############################################################################ #
-# Objects
-# ############################################################################ #
-
-const Configuration = preload("res://addons/inkgd/editor/configuration.gd")
-
-# ############################################################################ #
 # Properties
 # ############################################################################ #
 
-var configuration
+var configuration = preload("res://addons/inkgd/editor/configuration.gd").new()
 
 # ############################################################################ #
 # Nodes
@@ -50,9 +44,11 @@ onready var BuildOutputLabel = find_node("BuildOutputLabel")
 # Overrides
 # ############################################################################ #
 
-func _ready():
-    configuration = Configuration.new()
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		configuration.free()
 
+func _ready():
     MonoLineEdit.text = configuration.mono_path
     ExecutableLineEdit.text = configuration.inklecate_path
     SourceFileLineEdit.text = configuration.source_file_path


### PR DESCRIPTION
### Checklist for this pull request

- [YES] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [YES] I have checked that my code additions did not fail tests.

### Description

When building projects containing this add-on, the configuration instanced script starts leaking because it isn't disposed of properly. This fixes the leak.
