### PR TITLE
Removed icon_folder

### DIFF
--- a/addons/inkgd/editor/icons/icon_folder.svg
+++ b/addons/inkgd/editor/icons/icon_folder.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-<g transform="translate(0 -1036.4)">
-<path transform="translate(0 1036.4)" d="m2 2a1 1 0 0 0 -1 1v2 6 2a1 1 0 0 0 1 1h12a1 1 0 0 0 1 -1v-7a1 1 0 0 0 -1 -1h-4a1 1 0 0 1 -1 -1v-1a1 1 0 0 0 -1 -1h-6z" fill="#e0e0e0"/>
-</g>
-</svg>

--- a/addons/inkgd/editor/ink_dock.gd
+++ b/addons/inkgd/editor/ink_dock.gd
@@ -66,8 +66,11 @@ func _ready():
 
     MonoDialogButton.connect("pressed", self, "_mono_button_pressed")
     ExecutableDialogButton.connect("pressed", self, "_executable_button_pressed")
+    ExecutableDialogButton.icon = get_icon("Folder", "EditorIcons")
     SourceFileDialogButton.connect("pressed", self, "_source_file_button_pressed")
+    SourceFileDialogButton.icon = get_icon("Folder", "EditorIcons")
     TargetFileDialogButton.connect("pressed", self, "_target_file_button_pressed")
+    TargetFileDialogButton.icon = get_icon("Folder", "EditorIcons")
 
     TestButton.connect("pressed", self, "_test_button_pressed")
     BuildButton.connect("pressed", self, "_build_button_pressed")

--- a/addons/inkgd/editor/ink_dock.tscn
+++ b/addons/inkgd/editor/ink_dock.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://addons/inkgd/editor/ink_dock.gd" type="Script" id=1]
-[ext_resource path="res://addons/inkgd/editor/icons/icon_folder.svg" type="Texture" id=2]
 
 [node name="Ink" type="Control"]
 anchor_right = 1.0
@@ -93,7 +92,6 @@ text = "/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono"
 margin_left = 1885.0
 margin_right = 1913.0
 margin_bottom = 24.0
-icon = ExtResource( 2 )
 
 [node name="ExecutableLabel" type="Label" parent="VSplitContainer/MainVBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/GridContainer"]
 margin_top = 28.0
@@ -121,7 +119,6 @@ text = "/usr/local/Cellar/inklecate/0.8.2/libexec/inklecate.exe"
 margin_left = 1885.0
 margin_right = 1913.0
 margin_bottom = 24.0
-icon = ExtResource( 2 )
 
 [node name="SourceFileLabel" type="Label" parent="VSplitContainer/MainVBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/GridContainer"]
 margin_top = 56.0
@@ -149,7 +146,6 @@ text = "/Users/fred/Documents/Development/Godot/MollysFork/assets/stories/ink/ma
 margin_left = 1885.0
 margin_right = 1913.0
 margin_bottom = 24.0
-icon = ExtResource( 2 )
 
 [node name="TargetFileLabel" type="Label" parent="VSplitContainer/MainVBoxContainer/Panel/MarginContainer/ScrollContainer/VBoxContainer/GridContainer"]
 margin_top = 84.0
@@ -177,7 +173,6 @@ text = "/Users/fred/Documents/Development/Godot/MollysFork/assets/stories/story.
 margin_left = 1885.0
 margin_right = 1913.0
 margin_bottom = 24.0
-icon = ExtResource( 2 )
 
 [node name="MainVBoxContainer2" type="VBoxContainer" parent="VSplitContainer"]
 margin_top = 436.0


### PR DESCRIPTION
### Checklist for this pull request

- [X] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [X] I have checked that my code additions did not fail tests.

### Description

Building a project that uses inkgd with the help of [godot-ci](https://github.com/aBARICHELLO/godot-ci) gives several errors because of the icon_folder.SVG which, for some reason, cannot by loaded.

I don't know the exact cause of these errors, but the icon_folder can actually be removed since the editor folder icon can be accessed directly. (By using `get_icon("Folder", "EditorIcons")`)

DON'T MERGE YET, STILL HAVE TO VERIFY CI BEHAVIOUR AND DO ADDITIONAL TESTS!
