### PR TITLE
Fix missing folder icon in MonoDialogButton

### DIFF
--- a/addons/inkgd/editor/ink_dock.gd
+++ b/addons/inkgd/editor/ink_dock.gd
@@ -65,6 +65,7 @@ func _ready():
 	TargetFileLineEdit.connect("focus_exited", self, "_configuration_focus_exited")
 
 	MonoDialogButton.connect("pressed", self, "_mono_button_pressed")
+	MonoDialogButton.icon = get_icon("Folder", "EditorIcons")
 	ExecutableDialogButton.connect("pressed", self, "_executable_button_pressed")
 	ExecutableDialogButton.icon = get_icon("Folder", "EditorIcons")
 	SourceFileDialogButton.connect("pressed", self, "_source_file_button_pressed")


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

In the editor, the Mono dialog button is missing the folder icon. This change adds it. #36 names this problem.
