### PR TITLE
Remove inexistent path "asdasdasdasdads"

### DIFF
--- a/examples/scripts/ink_runner.gd
+++ b/examples/scripts/ink_runner.gd
@@ -129,8 +129,6 @@ func _async_load_completed():
 	_loading_thread = null
 
 	_bind_externals()
-	story.choose_path_string("asdasdasdasdads")
-	continue_story()
 	story.choose_path_string("start")
 	story.reset_errors()
 	continue_story()


### PR DESCRIPTION
These two lines make the example crash, when it should work out of the box. It seems there's no path named like that, and seems to be a mistake to have it there.

### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

Remove inexistent path, seems to be a mistake to have this here. Solves #38.
