### PR TITLE
Fix path not filled when file is selected

### DIFF
--- a/addons/inkgd/editor/ink_dock.gd
+++ b/addons/inkgd/editor/ink_dock.gd
@@ -13,13 +13,22 @@ extends Control
 # Properties
 # ############################################################################ #
 
+enum FileDialogSelectionEnum {
+	UNKNOWN,
+	MONO,
+	EXECUTABLE,
+	SOURCE_FILE,
+	TARGET_FILE
+}
+
 var configuration = preload("res://addons/inkgd/editor/configuration.gd").new()
 
 # ############################################################################ #
 # Nodes
 # ############################################################################ #
 
-var InkFileDialog = EditorFileDialog.new()
+onready var InkFileDialog = EditorFileDialog.new()
+onready var FileDialogSelection = FileDialogSelectionEnum.UNKNOWN
 
 onready var TestButton = find_node("TestButton")
 onready var BuildButton = find_node("BuildButton")
@@ -75,7 +84,7 @@ func _ready():
 
 	TestButton.connect("pressed", self, "_test_button_pressed")
 	BuildButton.connect("pressed", self, "_build_button_pressed")
-	InkFileDialog.connect("popup_hide", self, "_file_dialog_hide")
+	InkFileDialog.connect("file_selected", self, "_on_file_selected")
 
 	var is_windows = _is_running_on_windows()
 	MonoLabel.visible = !is_windows
@@ -94,7 +103,7 @@ func _ready():
 func _mono_button_pressed():
 	_reset_file_dialog()
 
-	InkFileDialog.connect("file_selected", self, "_mono_selected")
+	FileDialogSelection = FileDialogSelectionEnum.MONO
 	InkFileDialog.set_mode(FileDialog.MODE_OPEN_FILE)
 	InkFileDialog.set_access(FileDialog.ACCESS_FILESYSTEM)
 	InkFileDialog.popup_centered(Vector2(1280, 800))
@@ -102,7 +111,7 @@ func _mono_button_pressed():
 func _executable_button_pressed():
 	_reset_file_dialog()
 
-	InkFileDialog.connect("file_selected", self, "_executable_selected")
+	FileDialogSelection = FileDialogSelectionEnum.EXECUTABLE
 	InkFileDialog.set_mode(FileDialog.MODE_OPEN_FILE)
 	InkFileDialog.set_access(FileDialog.ACCESS_FILESYSTEM)
 	InkFileDialog.popup_centered(Vector2(1280, 800))
@@ -110,7 +119,7 @@ func _executable_button_pressed():
 func _source_file_button_pressed():
 	_reset_file_dialog()
 
-	InkFileDialog.connect("file_selected", self, "_source_file_selected")
+	FileDialogSelection = FileDialogSelectionEnum.SOURCE_FILE
 	InkFileDialog.set_mode(FileDialog.MODE_OPEN_FILE)
 	InkFileDialog.set_access(FileDialog.ACCESS_FILESYSTEM)
 	InkFileDialog.add_filter("*.ink;Ink source file")
@@ -119,37 +128,29 @@ func _source_file_button_pressed():
 func _target_file_button_pressed():
 	_reset_file_dialog()
 
-	InkFileDialog.connect("file_selected", self, "_target_file_selected")
+	FileDialogSelection = FileDialogSelectionEnum.TARGET_FILE
 	InkFileDialog.set_mode(FileDialog.MODE_SAVE_FILE)
 	InkFileDialog.set_access(FileDialog.ACCESS_FILESYSTEM)
 	InkFileDialog.add_filter("*.json;Compiled Ink project")
 	InkFileDialog.popup_centered(Vector2(1280, 800))
 
-func _file_dialog_hide():
-	if InkFileDialog.is_connected("file_selected", self, "_mono_selected"):
-		InkFileDialog.disconnect("file_selected", self, "_mono_selected")
-	elif InkFileDialog.is_connected("file_selected", self, "_source_file_selected"):
-		InkFileDialog.disconnect("file_selected", self, "_source_file_selected")
-	elif InkFileDialog.is_connected("file_selected", self, "_target_file_selected"):
-		InkFileDialog.disconnect("file_selected", self, "_target_file_selected")
-	elif InkFileDialog.is_connected("file_selected", self, "_executable_selected"):
-		InkFileDialog.disconnect("file_selected", self, "_executable_selected")
-
-func _mono_selected(path: String):
-	configuration.mono_path = ProjectSettings.globalize_path(path)
-	update_save_and_cleanup(configuration.mono_path, MonoLineEdit, "_mono_selected")
-
-func _source_file_selected(path: String):
-	configuration.source_file_path = ProjectSettings.localize_path(path)
-	update_save_and_cleanup(configuration.source_file_path, SourceFileLineEdit, "_source_file_selected")
-
-func _target_file_selected(path: String):
-	configuration.target_file_path = ProjectSettings.localize_path(path)
-	update_save_and_cleanup(configuration.target_file_path, TargetFileLineEdit, "_target_file_selected")
-
-func _executable_selected(path: String):
-	configuration.inklecate_path = ProjectSettings.globalize_path(path)
-	update_save_and_cleanup(configuration.inklecate_path, ExecutableLineEdit, "_executable_selected")
+func _on_file_selected(path: String):
+	match FileDialogSelection:
+		FileDialogSelectionEnum.MONO:
+			configuration.mono_path = ProjectSettings.globalize_path(path)
+			update_save_and_cleanup(configuration.mono_path, MonoLineEdit)
+		FileDialogSelectionEnum.EXECUTABLE:
+			configuration.inklecate_path = ProjectSettings.globalize_path(path)
+			update_save_and_cleanup(configuration.inklecate_path, ExecutableLineEdit)
+		FileDialogSelectionEnum.SOURCE_FILE:
+			configuration.source_file_path = ProjectSettings.localize_path(path)
+			update_save_and_cleanup(configuration.source_file_path, SourceFileLineEdit)
+		FileDialogSelectionEnum.TARGET_FILE:
+			configuration.target_file_path = ProjectSettings.localize_path(path)
+			update_save_and_cleanup(configuration.target_file_path, TargetFileLineEdit)
+		_:
+			printerr("Unknown FileDialogSelection, failed to save FileDialog file.")
+	FileDialogSelection = FileDialogSelectionEnum.UNKNOWN
 
 func _configuration_focus_exited():
 	configuration.mono_path = MonoLineEdit.text
@@ -211,14 +212,11 @@ func _reset_file_dialog():
 	InkFileDialog.current_file = ""
 	InkFileDialog.clear_filters()
 
-func update_save_and_cleanup(value, line_edit, method_name):
+func update_save_and_cleanup(value, line_edit):
 	line_edit.text = value
 	line_edit.update()
 
 	configuration.persist()
-
-	if InkFileDialog.is_connected("file_selected", self, method_name):
-		InkFileDialog.disconnect("file_selected", self, method_name)
 
 func _is_running_on_windows():
 	var os_name = OS.get_name()


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

Currently if one presses any folder button on the dock to the right, nothing happens. This is because the popup first emits `popup_hide` and then `file_selected`, causing the signal connection to break before `file_selected` is fired.

To solve this I propose adding an enum that will change depending on the button is pressed. It'll be redundant to use 4 identical `EditorFileDialog`, we can still use one and change it's parameters. A new variable will hold the enum of the button pressed, and `file_selected` will execute `_on_file_selected` method that'll do a match on the selected enum and perform the correct action. If the FileDialog is canceled then `file_selected0` is not fired and the enum continues holding the past value. This value is overriden when a new button is pressed.

If for some reason we end up with UNKNOWN that means this function was called from somewhere else other than the 4 buttons, which is not expected.
