### PR TITLE
Add myst_parser requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==4.3.0
 sphinx-rtd-theme==1.0.0
+myst-parser==0.15.2


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

Documentation is failing on "latest" branch because it can't find ´myst_parser´:

´´´
Running Sphinx v4.3.0
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/inkgd/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 429, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/inkgd/envs/latest/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'myst_parser'
´´´

Adding this requirement will trigger the installation of the missing module in ReadTheDocs, and deploy the current documentation.