### PR TITLE
Godot 4: fix infinite import/compilation loop

### DIFF
--- a/addons/inkgd/editor/common/ink_editor_interface.gd
+++ b/addons/inkgd/editor/common/ink_editor_interface.gd
@@ -14,7 +14,7 @@ class_name InkEditorInterface
 
 ## Emitted when 'Ink' resources (i. e. files with the '.ink' extension) were
 ## reimported by Godot.
-signal ink_ressources_reimported(resources)
+signal ink_resources_reimported(resources)
 
 # ############################################################################ #
 # Properties
@@ -81,4 +81,4 @@ func _resources_reimported(resources):
 		if resource.get_extension() == "ink":
 			ink_resources.append(resource)
 
-	emit_signal("ink_ressources_reimported", ink_resources)
+	emit_signal("ink_resources_reimported", ink_resources)

--- a/addons/inkgd/editor/panel/stories/ink_story_panel.gd
+++ b/addons/inkgd/editor/panel/stories/ink_story_panel.gd
@@ -105,7 +105,7 @@ func _ready():
 
 	configuration.connect("compilation_mode_changed", Callable(self, "_compilation_mode_changed"))
 
-	editor_interface.editor_filesystem.connect("resources_reimported", Callable(self, "_resources_reimported"))
+	editor_interface.connect("ink_resources_reimported", Callable(self, "_resources_reimported"))
 
 	_story_configuration_container.add_child(_empty_state_container)
 	add_child(_file_dialog)


### PR DESCRIPTION
Fix infinite loop that happens when the addon detects resource import, fires compilation, then detects a new import of produced `.json`s and fires compilation again.

The fix is to use `ink_resources_reimported` signal that only fires when `.ink` resources are reimported, opposed to editor filesystem signal that fires on any resource reimport.

Opportunistically fix the typo.

Tested on personal project under Godot 4.3. Didn't run any tests.