### PR TITLE
Fix _current_platform_supports_threads()

### DIFF
--- a/addons/inkgd/ink_player.gd
+++ b/addons/inkgd/ink_player.gd
@@ -845,7 +845,7 @@ func _remove_runtime() -> void:
 
 
 func _current_platform_supports_threads() -> bool:
-	return OS.get_name() != "HTML5"
+	return OS.has_feature("threads")
 
 
 func _push_null_runtime_error() -> void:


### PR DESCRIPTION
### Checklist for this pull request

- [x] I have read the [guidelines for contributing](../CONTRIBUTING.md).
- [x] I have checked that my code additions did not fail tests.

### Description

Update platform check to correctly detect if threads are supported. The previous version would always return true, because on the web OS.get_name() returns "Web" not "HTML5".